### PR TITLE
Add Parent-Child Relationships

### DIFF
--- a/client/src/engine/gameObject.js
+++ b/client/src/engine/gameObject.js
@@ -3,12 +3,71 @@ import { uuidv4 } from "../utils";
 
 
 export default class GameObject {
-  constructor(id,x,y,shouldRender=true) {
+  constructor(id,x,y,parent,{shouldRender=true}={}) {
     this.id = id || uuidv4()
     this.position = {x: x||0, y:y||0}
     this.shouldRender = shouldRender;
+    this.parent = parent;
+    this.children = []
     engine.registerGameObject(this.id, this);
   }
+
+  addChild(id) {
+    if (!this.children.includes(id)) {
+      this.children.push(id);
+    } else {
+      console.error(`${id} is already a child of ${this.parent}`)
+    }
+  }
+
+  renderChildren(ctx,canvas) {
+    this.children.forEach(child => child.render(ctx,canvas))
+  }
+
+  translatePointToRelative(pos) {
+    const stack = []
+    let relPos = {...pos}
+    let nextParentId = this.parent
+    // find the base of the tree
+    while (nextParentId) {
+      stack.push(nextParentId);
+      const parentObject = engine.getGameObject(nextParentId)
+      nextParentId = parentObject.parent;
+    }
+
+    // walk down the tree and apply transformations to the positions
+    while(stack.length !== 0) {
+      const parentId = stack.pop()
+      const parentObject = engine.getGameObject(parentId)
+      relPos = {
+        x: relPos.x - parentObject.position.x,
+        y: relPos.y - parentObject.position.y
+      }
+    }
+
+    return relPos
+
+  }
+
+  getAbsolutePosition() {
+    let maxIter =0
+    const absolutePosition = {...this.position}
+    let nextParentId = this.parent
+    while (nextParentId) {
+      const parentObject = engine.getGameObject(nextParentId)
+      if (parentObject && parentObject.position) {
+        absolutePosition.x = absolutePosition.x + parentObject.position.x;
+        absolutePosition.y = absolutePosition.y + parentObject.position.y
+        nextParentId = parentObject.parent
+      } else {
+        nextParentId = null
+      }
+      maxIter+=1
+      
+    }
+    return absolutePosition
+  }
+
   destroy() {
     engine.removeGameObject(this.id);
   }
@@ -25,6 +84,7 @@ export default class GameObject {
     return false;
   }
   render() {
+    this.renderChildren();
     // console.warn('Base GameObject does not have a render method!')
   }
 }

--- a/client/src/engine/line.js
+++ b/client/src/engine/line.js
@@ -5,7 +5,7 @@ import {GRID_SIZE} from './rendering/renderer'
 // TODO: change polygon to use x,y instead of array
 class Line extends GameObject {
   constructor(id,points,shouldRender) {
-    super(id,0,0,shouldRender)
+    super(id,0,0,null,{shouldRender: shouldRender})
     this.points = points || []
   } 
 

--- a/client/src/engine/polygon.js
+++ b/client/src/engine/polygon.js
@@ -5,7 +5,7 @@ import {GRID_SIZE} from './rendering/renderer'
 // TODO: change polygon to use x,y instead of array
 class Polygon extends GameObject {
   constructor(id,points,shouldRender) {
-    super(id,0,0,shouldRender)
+    super(id,0,0,null,{shouldRender: shouldRender})
     this.points = points || []
   } 
 

--- a/client/src/engine/rendering/renderer.js
+++ b/client/src/engine/rendering/renderer.js
@@ -85,7 +85,7 @@ export const render = () => {
   renderGrid(ctx,canvas);
   Object.keys(engine.getGameObjects()).forEach(id => {
     const go = engine.getGameObject(id);
-    if (go.shouldRender) {
+    if (go.shouldRender && go.parent === null) {
       go.render(ctx,canvas);  
     }
   });

--- a/client/src/engine/sprite.js
+++ b/client/src/engine/sprite.js
@@ -5,12 +5,12 @@ import { getAsset } from './assets/asset';
 import eventManager from './eventManager';
 
 class Sprite extends GameObject {
-  constructor(id, x,y,sprite,size,shouldRender=true,anchorPosition=null) {
-    super(id,x,y,shouldRender);
+  constructor(id, x,y,sprite,size,parent,options={shouldRender: true,anchorPosition: null}) {
+    super(id,x,y,parent,{ shouldRender: options.shouldRender });
     this.size = size;
     this.sprite = sprite;
     this.updatePosition = true; 
-    this.anchorPosition = anchorPosition || {x: 0, y: 0} 
+    this.anchorPosition = options.anchorPosition || {x: 0, y: 0} 
     eventManager.registerListener('mousedowngrid', (pos) => this.mouseDown(pos))
     eventManager.registerListener('mouseupgrid', (pos) => this.mouseUp(pos))
   }
@@ -19,10 +19,10 @@ class Sprite extends GameObject {
     if (!this.sprite) {
       return;
     }
-    
+    const absolutePosition = super.getAbsolutePosition()
     const relativePosition = {
-      x: (this.position.x - camera.data.x) + this.anchorPosition.x,
-      y: (this.position.y - camera.data.y) + this.anchorPosition.y
+      x: (absolutePosition.x - camera.data.x) + this.anchorPosition.x,
+      y: (absolutePosition.y - camera.data.y) + this.anchorPosition.y
     };
     // add a check here to see if it needs to be rendered
     ctx.save();
@@ -34,7 +34,8 @@ class Sprite extends GameObject {
       this.size * 2,
       this.size * 2,
     );
-    ctx.restore()
+    ctx.restore();
+    super.renderChildren(ctx,canvas)
    }
 }
 

--- a/client/src/engine/text.js
+++ b/client/src/engine/text.js
@@ -1,0 +1,31 @@
+import GameObject from './gameObject'
+import camera from './rendering/camera'
+import {GRID_SIZE} from './rendering/renderer'
+
+class Text extends GameObject {
+  constructor(id, x, y, text, parent, size=25) {
+    super(id,x,y,parent);
+    this.text = text
+    this.size = 50;
+  }
+  
+  render(ctx, canvas) {
+    const absolutePosition = super.getAbsolutePosition();
+    const relativePosition = {
+      x: (absolutePosition.x - camera.data.x), 
+      y: (absolutePosition.y - camera.data.y) 
+    }
+    ctx.font = '20px serif';
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(
+      this.text, 
+      relativePosition.x*GRID_SIZE/2 + canvas.width / 2, 
+      relativePosition.y*GRID_SIZE/2 + canvas.height / 2, 
+      this.size*2
+    );
+    ctx.restore()
+  }
+}
+
+export default Text

--- a/client/src/game/drawingTool.js
+++ b/client/src/game/drawingTool.js
@@ -1,6 +1,0 @@
-
-
-
-class DrawingTool {
-  
-}

--- a/client/src/game/game.js
+++ b/client/src/game/game.js
@@ -5,6 +5,8 @@ import TokenManager from './tokenManager';
 import ShapeCreator from './shapeCreator'
 import LineCreator from './lineCreator'
 import Polygon from '../engine/polygon';
+import Text from '../engine/text'
+
 // this looks weird
 const load = () => {
   new CameraMovement();

--- a/client/src/game/lineCreator.js
+++ b/client/src/game/lineCreator.js
@@ -7,7 +7,7 @@ import { addEntity } from '../engine/networking/networking';
 class LineCreator extends Sprite {
 
   constructor() {
-    super(null, 25.5,25.5,'pencil.svg',10,false,{x: 0.2, y: -0.2});
+    super(null, 25.5,25.5,'pencil.svg',10,null,{shouldRender: false, anchorPosition: {x: 0.2, y: -0.2}});
     this.points = []
     this.active = false;
     this.currentLine = null

--- a/client/src/game/shapeCreator.js
+++ b/client/src/game/shapeCreator.js
@@ -7,7 +7,7 @@ import { addEntity } from '../engine/networking/networking';
 class ShapeCreator extends Sprite {
 
   constructor() {
-    super(null, 25.5,25.5,'pencil.svg',10,false,{x: 0.2, y: -0.2});
+    super('shape-creator', 25.5,25.5,'pencil.svg',10,null,{shouldRender: false,anchorPosition: {x: 0.2, y: -0.2}});
     this.points = []
     this.active = false;
     this.currentPolygon = null
@@ -66,10 +66,6 @@ class ShapeCreator extends Sprite {
         y:Math.floor(getMousePositionIntersection().y) - 0.5
       }
   }
-
-  
-
-
 }
 
 export default ShapeCreator

--- a/client/src/game/squareHightlight.js
+++ b/client/src/game/squareHightlight.js
@@ -4,7 +4,7 @@ import { getMousePositionCentreGrid } from '../engine/input/input';
 
 export default class SquareHighlight extends Sprite {
   constructor() {
-    super('gridHighlight',25,25,'gridHighlight.svg',25,false);
+    super('gridHighlight',25,25,'gridHighlight.svg',25,null,{shouldRender: false});
     this.isMouseDown = false;
     this.show = false
     this.triggerShow = this.triggerShow.bind(this)

--- a/client/src/game/token.js
+++ b/client/src/game/token.js
@@ -2,21 +2,38 @@ import eventManager from '../engine/eventManager';
 import Sprite from '../engine/sprite'
 import { getMousePositionCentreGrid } from '../engine/input/input';
 import {createEntityUpdate} from '../engine/statemanagement/state'
+import Text from '../engine/text'
+import { uuidv4 } from '../utils';
 
 export default class Token extends Sprite {
-  constructor(id, x, y, sprite, size) {
-    super(id,x,y,sprite,size);
+  constructor(id, x, y, size, t=true, options={parent: null, text: 'T1'}) {
+    super(id,x,y,'token.svg',size,options.parent);
     this.isMouseDown = false;
+    super.addChild(new Text(`${id}-text`,0,0,options.text,id))
+    if (t) {
+      console.log('add child')
+      super.addChild(new Token(uuidv4(), 1,1,20,false,{parent: id, text: 'T2'}))
+    }
+  }
+
+  start() {
+    console.log(`${this.id} start`)
   }
 
   mouseDown(pos) {
-    if (Math.floor(pos.x) === this.position.x && Math.floor(pos.y) === this.position.y) {
+    const absolutePosition = this.getAbsolutePosition()
+    if (Math.floor(pos.x) === absolutePosition.x && Math.floor(pos.y) === absolutePosition.y) {
       this.isMouseDown = true;
     }
   } 
   
   mouseUp() {
-    this.isMouseDown && createEntityUpdate({ id: this.id, position: {x: Math.floor(getMousePositionCentreGrid().x), y: Math.floor(getMousePositionCentreGrid().y) }})
+    const newPosition = {
+      x: getMousePositionCentreGrid().x,
+      y: getMousePositionCentreGrid().y
+    }
+    const relativePosition = super.translatePointToRelative(newPosition);
+    this.isMouseDown && createEntityUpdate({ id: this.id, position: {x: Math.floor(relativePosition.x), y: Math.floor(relativePosition.y) }})
     super.updatePosition = true;
     this.isMouseDown = false;
   }
@@ -27,7 +44,8 @@ export default class Token extends Sprite {
         x: getMousePositionCentreGrid().x - 0.5,
         y: getMousePositionCentreGrid().y - 0.5
       }
-      createEntityUpdate({id: this.id, position: {x: newPosition.x, y: newPosition.y}})
+      const relativePosition = super.translatePointToRelative(newPosition);
+      createEntityUpdate({id: this.id, position: {x: relativePosition.x, y: relativePosition.y}})
     }
   }
 }


### PR DESCRIPTION
Restructures game objects to have a parent-child structure. Objects with no parent's render function is called by the engine, the object is then responsible for rendering its children (not sure I like this much -- but it works for now). 

Adds a function to calculate a game object's position based on its parents and a function to transform a global coordinate into a game object's space. 

Adds a text object

![out](https://user-images.githubusercontent.com/31216525/104848467-fa47f000-58dc-11eb-96aa-3bf5dcea0a5d.gif)
 
